### PR TITLE
Use WebGL1 by default for 8frame-1.1.0.

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -629,7 +629,7 @@ module.exports.AScene = registerElement('a-scene', {
 
         this.maxCanvasSize = {height: 1920, width: 1920};
 
-        let useWebGL1 = false;
+        let useWebGL2 = false;
         if (this.hasAttribute('renderer')) {
           rendererAttrString = this.getAttribute('renderer');
           rendererAttr = utils.styleParser.parse(rendererAttrString);
@@ -654,8 +654,8 @@ module.exports.AScene = registerElement('a-scene', {
             rendererConfig.preserveDrawingBuffer = rendererAttr.preserveDrawingBuffer === 'true';
           }
 
-          if (rendererAttr.useWebGL1) {
-            useWebGL1 = rendererAttr.useWebGL1 === 'true';
+          if (rendererAttr.webgl2) {
+            useWebGL2 = rendererAttr.webgl2 === 'true';
           }
 
           this.maxCanvasSize = {
@@ -668,8 +668,8 @@ module.exports.AScene = registerElement('a-scene', {
           };
         }
 
-        renderer = this.renderer = useWebGL1
-          ? new THREE.WebGL1Renderer(rendererConfig) : new THREE.WebGLRenderer(rendererConfig);
+        renderer = this.renderer = useWebGL2
+          ? new THREE.WebGLRenderer(rendererConfig) : new THREE.WebGL1Renderer(rendererConfig);
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
         if (this.camera) { renderer.xr.setPoseTarget(this.camera.el.object3D); }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -629,6 +629,7 @@ module.exports.AScene = registerElement('a-scene', {
 
         this.maxCanvasSize = {height: 1920, width: 1920};
 
+        let useWebGL1 = false;
         if (this.hasAttribute('renderer')) {
           rendererAttrString = this.getAttribute('renderer');
           rendererAttr = utils.styleParser.parse(rendererAttrString);
@@ -653,6 +654,10 @@ module.exports.AScene = registerElement('a-scene', {
             rendererConfig.preserveDrawingBuffer = rendererAttr.preserveDrawingBuffer === 'true';
           }
 
+          if (rendererAttr.useWebGL1) {
+            useWebGL1 = rendererAttr.useWebGL1 === 'true';
+          }
+
           this.maxCanvasSize = {
             width: rendererAttr.maxCanvasWidth
               ? parseInt(rendererAttr.maxCanvasWidth)
@@ -663,7 +668,8 @@ module.exports.AScene = registerElement('a-scene', {
           };
         }
 
-        renderer = this.renderer = new THREE.WebGLRenderer(rendererConfig);
+        renderer = this.renderer = useWebGL1
+          ? new THREE.WebGL1Renderer(rendererConfig) : new THREE.WebGLRenderer(rendererConfig);
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
         if (this.camera) { renderer.xr.setPoseTarget(this.camera.el.object3D); }

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -629,6 +629,8 @@ module.exports.AScene = registerElement('a-scene', {
 
         this.maxCanvasSize = {height: 1920, width: 1920};
 
+        // By default, we are having 8Frame 1.1.0 run WebGL1 instead of vanilla Aframe-1.1.0's
+        // default behavior of using WebGL2.
         let useWebGL2 = false;
         if (this.hasAttribute('renderer')) {
           rendererAttrString = this.getAttribute('renderer');

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ require('./core/a-mixin');
 require('./extras/components/');
 require('./extras/primitives/');
 
-console.log('8-Frame Version: 1.1.0 (Date 2020-12-07, Commit #caa649a0)');
+console.log('8-Frame Version: 1.1.0 (Date 2020-12-12, Commit #8631e97e)');
 console.log('three Version (https://github.com/supermedium/three.js):',
             pkg.dependencies['super-three']);
 console.log('WebVR Polyfill Version:', pkg.dependencies['webvr-polyfill']);

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ require('./core/a-mixin');
 require('./extras/components/');
 require('./extras/primitives/');
 
-console.log('8-Frame Version: 1.1.0 (Date 2020-12-12, Commit #8631e97e)');
+console.log('8-Frame Version: 1.1.0 (Date 2020-12-07, Commit #caa649a0)');
 console.log('three Version (https://github.com/supermedium/three.js):',
             pkg.dependencies['super-three']);
 console.log('WebVR Polyfill Version:', pkg.dependencies['webvr-polyfill']);

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -21,7 +21,8 @@ module.exports.System = registerSystem('renderer', {
     colorManagement: {default: false},
     gammaOutput: {default: false},
     alpha: {default: true},
-    foveationLevel: {default: 0}
+    foveationLevel: {default: 0},
+    useWebGL1: {default: false}
   },
 
   init: function () {

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -22,7 +22,7 @@ module.exports.System = registerSystem('renderer', {
     gammaOutput: {default: false},
     alpha: {default: true},
     foveationLevel: {default: 0},
-    useWebGL1: {default: false}
+    webgl2: {default: false}
   },
 
   init: function () {


### PR DESCRIPTION
Allow users to specify renderer="webgl2: true;" to specify WebGL2.
By default, it will do WebGL1.
