### PR TITLE
MSDF WebGL1 fix

### DIFF
--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -52,6 +52,18 @@ Shader.prototype = {
   init: function (data) {
     this.attributes = this.initVariables(data, 'attribute');
     this.uniforms = this.initVariables(data, 'uniform');
+
+    // msdf uses webgl2 by default during initialization.  If we are using a WebGL1 renderer, this
+    // will error.  Therefore, switch to the WebGL1 shaders here for msdf renderer if we're using
+    // WebGL1.
+    if (this.name === 'msdf' &&
+        this.el.sceneEl &&
+        this.el.sceneEl.renderer &&
+        this.el.sceneEl.renderer.isWebGL1Renderer) {
+      this.vertexShader = this.vertexShaderWebGL1
+      this.fragmentShader = this.fragmentShaderWebGL1
+    }
+
     this.material = new (this.raw ? THREE.RawShaderMaterial : THREE.ShaderMaterial)({
       // attributes: this.attributes,
       uniforms: this.uniforms,

--- a/src/shaders/msdf.js
+++ b/src/shaders/msdf.js
@@ -134,6 +134,8 @@ module.exports.Shader = registerShader('msdf', {
   raw: true,
 
   vertexShader: VERTEX_SHADER,
+  vertexShaderWebGL1: VERTEX_SHADER_WEBGL1,
 
-  fragmentShader: FRAGMENT_SHADER
+  fragmentShader: FRAGMENT_SHADER,
+  fragmentShaderWebGL1: FRAGMENT_SHADER_WEBGL1
 });


### PR DESCRIPTION
By default, 8frame uses WebGL1.

The MSDF text renderer shader uses webgl2 by default.  This makes sure it's using the right shaders for the webgl version.