### PR TITLE
8frame 1.1.0 sdf webgl1 patch

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -659,8 +659,8 @@ module.exports.AScene = registerElement('a-scene', {
           if (rendererAttr.webgl2) {
             // We only want to use WebGL2 if they explicitly specify 'renderer: "webgl2: true"' and
             // their device is capable of webgl2 rendering.
-            const isWebGL2AVailable = !!document.createElement('canvas').getContext('webgl2');
-            useWebGL2 = rendererAttr.webgl2 === 'true' && isWebGL2AVailable;
+            const isWebGL2Available = !!document.createElement('canvas').getContext('webgl2');
+            useWebGL2 = rendererAttr.webgl2 === 'true' && isWebGL2Available;
           }
 
           this.maxCanvasSize = {

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -657,7 +657,10 @@ module.exports.AScene = registerElement('a-scene', {
           }
 
           if (rendererAttr.webgl2) {
-            useWebGL2 = rendererAttr.webgl2 === 'true';
+            // We only want to use WebGL2 if they explicitly specify 'renderer: "webgl2: true"' and
+            // their device is capable of webgl2 rendering.
+            const isWebGL2AVailable = !!document.createElement('canvas').getContext('webgl2');
+            useWebGL2 = rendererAttr.webgl2 === 'true' && isWebGL2AVailable;
           }
 
           this.maxCanvasSize = {

--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -53,10 +53,10 @@ Shader.prototype = {
     this.attributes = this.initVariables(data, 'attribute');
     this.uniforms = this.initVariables(data, 'uniform');
 
-    // msdf uses webgl2 by default during initialization.  If we are using a WebGL1 renderer, this
-    // will error.  Therefore, switch to the WebGL1 shaders here for msdf renderer if we're using
-    // WebGL1.
-    if (this.name === 'msdf' &&
+    // msdf and sdf use webgl2 by default during initialization.  If we are using a WebGL1 renderer,
+    // this will error.  Therefore, switch to the WebGL1 shaders here for the shaders if we're
+    // using WebGL1.
+    if ((this.name === 'msdf' || this.name === 'sdf') &&
         this.el.sceneEl &&
         this.el.sceneEl.renderer &&
         this.el.sceneEl.renderer.isWebGL1Renderer) {

--- a/src/shaders/sdf.js
+++ b/src/shaders/sdf.js
@@ -27,6 +27,18 @@ module.exports.Shader = registerShader('sdf', {
     '}'
   ].join('\n'),
 
+  vertexShaderWebGL1: [
+    'attribute vec2 uv;',
+    'attribute vec3 position;',
+    'uniform mat4 projectionMatrix;',
+    'uniform mat4 modelViewMatrix;',
+    'varying vec2 vUV;',
+    'void main(void) {',
+    '  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);',
+    '  vUV = uv;',
+    '}'
+  ].join('\n'),
+
   fragmentShader: [
     '#version 300 es',
     'precision highp float;',
@@ -106,6 +118,90 @@ module.exports.Shader = registerShader('sdf', {
     '  #endif',
 
     '  fragColor = vec4(color, opacity * alpha);',
+    '}'
+  ].join('\n'),
+
+  fragmentShaderWebGL1: [
+    '#ifdef GL_OES_standard_derivatives',
+    '#extension GL_OES_standard_derivatives: enable',
+    '#endif',
+
+    'precision highp float;',
+    'uniform float alphaTest;',
+    'uniform float opacity;',
+    'uniform sampler2D map;',
+    'uniform vec3 color;',
+    'varying vec2 vUV;',
+
+    '#ifdef GL_OES_standard_derivatives',
+    '  float contour(float width, float value) {',
+    '    return smoothstep(0.5 - value, 0.5 + value, width);',
+    '  }',
+    '#else',
+    '  float aastep(float value, float afwidth) {',
+    '    return smoothstep(0.5 - afwidth, 0.5 + afwidth, value);',
+    '  }',
+    '#endif',
+
+    // FIXME: Experimentally determined constants.
+    '#define BIG_ENOUGH 0.001',
+    '#define MODIFIED_ALPHATEST (0.02 * isBigEnough / BIG_ENOUGH)',
+    '#define ALL_SMOOTH 0.4',
+    '#define ALL_ROUGH 0.02',
+    '#define DISCARD_ALPHA (alphaTest / (2.2 - 1.2 * ratio))',
+
+    'void main() {',
+       // When we have derivatives and can get texel size for supersampling.
+    '  #ifdef GL_OES_standard_derivatives',
+    '    vec2 uv = vUV;',
+    '    vec4 texColor = texture2D(map, uv);',
+    '    float dist = texColor.a;',
+    '    float width = fwidth(dist);',
+    '    float alpha = contour(dist, width);',
+    '    float dscale = 0.353505;',
+
+    '    vec2 duv = dscale * (dFdx(uv) + dFdy(uv));',
+    '    float isBigEnough = max(abs(duv.x), abs(duv.y));',
+
+         // When texel is too small, blend raw alpha value rather than supersampling.
+         // FIXME: experimentally determined constant
+    '    if (isBigEnough > BIG_ENOUGH) {',
+    '      float ratio = BIG_ENOUGH / isBigEnough;',
+    '      alpha = ratio * alpha + (1.0 - ratio) * dist;',
+    '    }',
+
+         // Otherwise do weighted supersampling.
+         // FIXME: why this weighting?
+    '    if (isBigEnough <= BIG_ENOUGH) {',
+    '      vec4 box = vec4 (uv - duv, uv + duv);',
+    '      alpha = (alpha + 0.5 * (',
+    '        contour(texture2D(map, box.xy).a, width)',
+    '        + contour(texture2D(map, box.zw).a, width)',
+    '        + contour(texture2D(map, box.xw).a, width)',
+    '        + contour(texture2D(map, box.zy).a, width)',
+    '      )) / 3.0;',
+    '    }',
+
+         // Do modified alpha test.
+    '    if (alpha < alphaTest * MODIFIED_ALPHATEST) { discard; return; }',
+
+    '  #else',
+         // When we don't have derivatives, use approximations.
+    '    vec4 texColor = texture2D(map, vUV);',
+    '    float value = texColor.a;',
+         // FIXME: if we understood font pixel dimensions, this could probably be improved
+    '    float afwidth = (1.0 / 32.0) * (1.4142135623730951 / (2.0 * gl_FragCoord.w));',
+    '    float alpha = aastep(value, afwidth);',
+
+         // Use gl_FragCoord.w to guess when we should blend.
+         // FIXME: If we understood font pixel dimensions, this could probably be improved.
+    '    float ratio = (gl_FragCoord.w >= ALL_SMOOTH) ? 1.0 : (gl_FragCoord.w < ALL_ROUGH) ? 0.0 : (gl_FragCoord.w - ALL_ROUGH) / (ALL_SMOOTH - ALL_ROUGH);',
+    '    if (alpha < alphaTest) { if (ratio >= 1.0) { discard; return; } alpha = 0.0; }',
+    '    alpha = alpha * ratio + (1.0 - ratio) * value;',
+    '    if (ratio < 1.0 && alpha <= DISCARD_ALPHA) { discard; return; }',
+    '  #endif',
+
+    '  gl_FragColor = vec4(color, opacity * alpha);',
     '}'
   ].join('\n')
 });


### PR DESCRIPTION
SDF, an alternative text renderer to WSDF, was not WebGL1 compatible. 
Also, setting `renderer: "webgl2: true"` now still sets a WebGL1 renderer for platforms like iOS that do not support WebGL2.
