### PR TITLE
handle enterVR xr.request session reject

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -316,7 +316,9 @@ module.exports.AScene = registerElement('a-scene', {
                 function requestFail (error) {
                   var useAR = xrMode === 'immersive-ar';
                   var mode = useAR ? 'AR' : 'VR';
-                  throw new Error('Failed to enter ' + mode + ' mode (`requestSession`) ' + error);
+                  reject(
+                    new Error('Failed to enter ' + mode + ' mode (`requestSession`) ' + error)
+                  );
                 }
               );
             });


### PR DESCRIPTION
**Description:**
we are currently can't enter vr session without prompt from A-frame due errors from `xr.requestionsession` not being handled by a-frame

https://github.com/8thwall/code8/issues/20233
**Changes proposed:**
- Call Promise.reject from outer scope when error
