### PR TITLE
[8frame-1.3.0] use WebGL2 by default

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -630,9 +630,9 @@ module.exports.AScene = registerElement('a-scene', {
 
         this.maxCanvasSize = {height: 1920, width: 1920};
 
-        // By default, we are having 8Frame 1.1.0 run WebGL1 instead of vanilla Aframe-1.1.0's
-        // default behavior of using WebGL2.
-        let useWebGL2 = false;
+        // Use WebGL2 as long as it is available, similar to vanilla Aframe-1.3.0.
+        let useWebGL2 = !!document.createElement('canvas').getContext('webgl2');
+
         if (this.hasAttribute('renderer')) {
           rendererAttrString = this.getAttribute('renderer');
           rendererAttr = utils.styleParser.parse(rendererAttrString);
@@ -658,10 +658,8 @@ module.exports.AScene = registerElement('a-scene', {
           }
 
           if (rendererAttr.webgl2) {
-            // We only want to use WebGL2 if they explicitly specify 'renderer: "webgl2: true"' and
-            // their device is capable of webgl2 rendering.
-            const isWebGL2Available = !!document.createElement('canvas').getContext('webgl2');
-            useWebGL2 = rendererAttr.webgl2 === 'true' && isWebGL2Available;
+            // We only want to use WebGL 1 if they explicitly specify 'renderer: "webgl2: false"'.
+            useWebGL2 = rendererAttr.webgl2 !== 'false';
           }
 
           this.maxCanvasSize = {
@@ -673,6 +671,8 @@ module.exports.AScene = registerElement('a-scene', {
               : this.maxCanvasSize.height
           };
         }
+
+        console.log('[a-frame] using WebGL2: ', useWebGL2);
 
         renderer = this.renderer = useWebGL2
           ? new THREE.WebGLRenderer(rendererConfig) : new THREE.WebGL1Renderer(rendererConfig);

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -632,7 +632,7 @@ module.exports.AScene = registerElement('a-scene', {
 
         // Use WebGL2 as long as it is available or the user specifies webgl2: false.  Aframe-1.3.0
         // is also WebGL2 by default.
-        let useWebGL2 = !!document.createElement('canvas').getContext('webgl2');
+        let useWebGL2 = true;
 
         if (this.hasAttribute('renderer')) {
           rendererAttrString = this.getAttribute('renderer');
@@ -671,6 +671,11 @@ module.exports.AScene = registerElement('a-scene', {
               ? parseInt(rendererAttr.maxCanvasHeight)
               : this.maxCanvasSize.height
           };
+        }
+
+        // Even if the user wants webgl2, if it's not available then fall back to webgl1.
+        if (!document.createElement('canvas').getContext('webgl2')) {
+          useWebGL2 = false;
         }
 
         renderer = this.renderer = useWebGL2

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -674,7 +674,7 @@ module.exports.AScene = registerElement('a-scene', {
         }
 
         // Even if the user wants webgl2, if it's not available then fall back to webgl1.
-        if (!document.createElement('canvas').getContext('webgl2')) {
+        if (useWebGL2 && !document.createElement('canvas').getContext('webgl2')) {
           useWebGL2 = false;
         }
 

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -672,8 +672,6 @@ module.exports.AScene = registerElement('a-scene', {
           };
         }
 
-        console.log('[a-frame] using WebGL2: ', useWebGL2);
-
         renderer = this.renderer = useWebGL2
           ? new THREE.WebGLRenderer(rendererConfig) : new THREE.WebGL1Renderer(rendererConfig);
         renderer.setPixelRatio(window.devicePixelRatio);

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -630,7 +630,8 @@ module.exports.AScene = registerElement('a-scene', {
 
         this.maxCanvasSize = {height: 1920, width: 1920};
 
-        // Use WebGL2 as long as it is available, similar to vanilla Aframe-1.3.0.
+        // Use WebGL2 as long as it is available or the user specifies webgl2: false.  Aframe-1.3.0
+        // is also WebGL2 by default.
         let useWebGL2 = !!document.createElement('canvas').getContext('webgl2');
 
         if (this.hasAttribute('renderer')) {
@@ -658,7 +659,7 @@ module.exports.AScene = registerElement('a-scene', {
           }
 
           if (rendererAttr.webgl2) {
-            // We only want to use WebGL 1 if they explicitly specify 'renderer: "webgl2: false"'.
+            // If the user specifies 'renderer: "webgl2: false"' then we will use webgl 1.
             useWebGL2 = rendererAttr.webgl2 !== 'false';
           }
 


### PR DESCRIPTION
# Context

Now that we are past the iPhone webgl2 issues, we can now be WebGL2 by default.  AFrame has been WebGL2 by default since 1.1.0.  All of our other rendering engines are also webgl2 by default.

# Testing
`renderer=''` -> uses WebGL2 
`renderer="webgl2: true"` -> uses WebGL2 
`renderer="webgl2: false"` -> uses WebGL1