### PR TITLE
[aframe-1.4.1] update npm run dist build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/aframe-master.js",
   "scripts": {
     "dev": "cross-env INSPECTOR_VERSION=dev webpack serve --port 8080",
-    "dist": "node scripts/updateVersionLog.js && node scripts/buildTo.js",
+    "dist": "rm -rf dist && node scripts/updateVersionLog.js && node scripts/buildTo.js",
     "dist:max": "webpack --config webpack.config.js",
     "dist:min": "webpack --config webpack.prod.config.js",
     "docs": "markserv --dir docs --port 9001",

--- a/scripts/buildTo.js
+++ b/scripts/buildTo.js
@@ -1,12 +1,12 @@
 var execSync = require('child_process').execSync;
 var pkg = require('../package.json');
 
-var name = process.argv[2] || '8frame-master';
+var name = process.argv[2] || '8frame-master.js';
 
 console.log('Building 8frame as:', name);
 
-const distMin = pkg.scripts['dist:min'].replace(/aframe-master/g, name);
-const distMax = pkg.scripts['dist:max'].replace(/aframe-master/g, name);
+const distMin = pkg.scripts['dist:min'] + ` --output-filename ${name}`;
+const distMax = pkg.scripts['dist:max'] + ` --output-filename ${name}`;
 
 console.log('>', distMin);
 execSync(distMin, {stdio: 'inherit'});


### PR DESCRIPTION
## What

Aframe changed their build process [here](https://github.com/aframevr/aframe/pull/5116); 

Here we use a [webpack setting ](https://v4.webpack.js.org/api/cli/#output-options) to name the output file instead. 