### PR TITLE
[quality] Fix crash with undefined checkVRSupport() method

### DIFF
--- a/src/components/scene/vr-mode-ui.js
+++ b/src/components/scene/vr-mode-ui.js
@@ -135,10 +135,10 @@ module.exports.Component = registerComponent('vr-mode-ui', {
     var sceneEl = this.el;
     if (!this.enterVREl) { return; }
     if (sceneEl.is('vr-mode') ||
-       ((sceneEl.isMobile || utils.device.isMobileDeviceRequestingDesktopSite()) && !this.data.cardboardModeEnabled && !utils.device.checkVRSupport())) {
+       ((sceneEl.isMobile || utils.device.isMobileDeviceRequestingDesktopSite()) && !this.data.cardboardModeEnabled && (utils.device.checkVRSupport && !utils.device.checkVRSupport()))) {
       this.enterVREl.classList.add(HIDDEN_CLASS);
     } else {
-      if (!utils.device.checkVRSupport()) { this.enterVREl.classList.add('fullscreen'); }
+      if ((utils.device.checkVRSupport && !utils.device.checkVRSupport())) { this.enterVREl.classList.add('fullscreen'); }
       this.enterVREl.classList.remove(HIDDEN_CLASS);
     }
   },


### PR DESCRIPTION
### What
When building locally and on visiting this page on desktop https://localhost:8080/showcase/anime-UI/ we get this error:
```
vr-mode-ui.js:141 Uncaught (in promise) TypeError: utils.device.checkVRSupport is not a function
    at NewComponent.toggleEnterVRButtonIfNeeded (vr-mode-ui.js:141:25)
    at NewComponent.updateEnterInterfaces (vr-mode-ui.js:129:10)
    at NewComponent.bound [as updateEnterInterfaces] (bind.js:12:17)
    at NewComponent.update (vr-mode-ui.js:114:10)
    at NewComponent.initComponent (component.js:333:10)
    at NewComponent.updateProperties (component.js:305:12)
    at AScene.updateComponent (a-entity.js:466:17)
    at AScene.updateComponent (a-scene.js:681:39)
    at AScene.updateComponents (a-entity.js:442:12)
    at entityLoadCallback (a-entity.js:243:12)
```

![Screen Shot 2023-02-24 at 2 24 57 PM](https://user-images.githubusercontent.com/1396242/221305057-77de40c5-edb2-42df-b6de-a95c87beb3f0.png)

We fix it by checking if `checkVRSupport()` is a function.

### Testing
Now we have no errors and the page loads:

![Screen Shot 2023-02-24 at 2 22 52 PM](https://user-images.githubusercontent.com/1396242/221304910-16b3aad6-4f89-4ac6-8245-e6fad2314b3b.png)



