### PR TITLE
[quality] Check for 'vr-mode-ui' on sceneEl before acccessing it

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -33,7 +33,9 @@ if (isWebXRAvailable) {
       return;
     }
     if (sceneEl.hasLoaded) {
-      sceneEl.components['vr-mode-ui'].updateEnterInterfaces();
+      if (sceneEl.components['vr-mode-ui']) {
+        sceneEl.components['vr-mode-ui'].updateEnterInterfaces();
+      }
     } else {
       sceneEl.addEventListener('loaded', updateEnterInterfaces);
     }
@@ -90,9 +92,6 @@ module.exports.checkHeadsetConnected = checkHeadsetConnected;
 
 function checkARSupport () { return supportsARSession; }
 module.exports.checkARSupport = checkARSupport;
-
-function checkVRSupport () { return supportsVRSession; }
-module.exports.checkVRSupport = checkVRSupport;
 
 /**
  * Checks if browser is mobile and not stand-alone dedicated vr device.


### PR DESCRIPTION
### What
When self-hosting an 8th Wall experience and using 8frame and opening it on desktop Chrome you will get this error:
```
device.js:36 Uncaught TypeError: Cannot read properties of undefined (reading 'updateEnterInterfaces')
    at HTMLElement.updateEnterInterfaces (device.js:36:40)
    at HTMLElement.<anonymous> (a-node.js:263:16)
    at a-node.js:128:16
```

![Screen Shot 2023-02-24 at 2 36 25 PM](https://user-images.githubusercontent.com/1396242/221308558-b8b1a71d-fca7-407e-915e-125b2620b940.png)

This may be because the 8th Wall aframe layer manually removes `'vr-mode-ui'`. So here we just check if it is present before accessing it.

One note is that this doesn't seem to harm the experience, but I'm fixing it to be sure.

### Testing
Now we have no errors and experience loads.

